### PR TITLE
Draft accepting/maintaining pages

### DIFF
--- a/accepting-projects.html
+++ b/accepting-projects.html
@@ -1,0 +1,64 @@
+<head>
+    <style type="text/css">
+        body {
+            margin: 40px auto;
+            max-width: 650px;
+            line-height: 1.6;
+            font-size: 18px;
+            color: #444;
+            padding: 0 10px
+        }
+
+        h1,
+        h2,
+        h3 {
+            line-height: 1.2
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Accepting Projects</h1>
+
+<p>Before adopting a project into CLJ Commons, there are some entry criteria that need to be satisfied:</p>
+
+<ul>
+<li>The project is 'unmaintained'. This is subjective, and there are many libraries which are just 'done'. Indications that a project is unmaintained could be: the library breaking with new Java or Clojure versions, issues and PRs not being addressed for years, no recent releases, no commits for years, or the maintainer is no longer involved with Clojure.</li>
+<li>The project is notable, useful, and currently being used by people. This is inherently subjective, but some evidence for this could be number of stars on GitHub, recent issues/PRs, number of downloads on Clojars, how much work went into creating it, or if any notable projects depend on it. An example of a project that wouldn't be accepted is a small library created by one person that only they use.</li>
+<li>There is at least one person who wants to be a maintainer of the project. These maintainers will be listed in a <code>CODEOWNERS<code> file. We don't want the new home of the project to become unmaintained as well.</li>
+<li>We have attempted to talk to the original owner of the project and they are happy to transfer the project. The goal is not to be forking projects away from people who want to manage the project themselves.</li>
+</ul>
+
+<h2>Proposing a Project</h2>
+
+<p>If you would like to see a project transferred to CLJ Commons for future maintenance that you believe meets the above criteria, you can <a href="https://github.com/clj-commons/meta/issues">create an issue to propose the project</a>, providing relevant information about the project's use, and suggesting a new maintainer (or volunteering to maintain it yourself).</p>
+
+<p>The CLJ Commons team will review the proposal, based on the criteria above, and if at least two members of the team agree that the project should be transferred, we will attempt to contact the original owner of the project to discuss the transfer. Currently, that team is <a href="https://github.com/slipset">Erik Assum</a>, <a href="https://github.com/danielcompton">Daniel Compton</a>, and <a href="https://github.com/seancorfield">Sean Corfield</a>.</p>
+
+<h2>Transferring a Project</h2>
+
+<p>When a project is adopted into the <code>clj-commons</code> organization on GitHub, a transfer of ownership is preferred over forking.
+ There are several reasons for this:</p>
+<ul>
+<li>The adoption is somewhat formalized and friendly, the original authors need to give their blessing for
+ this to happen,</li>
+<li>All GitHub metainfo, stars, issues, PRs, etc are transferred in a transfer, but lost in a fork.</li>
+</ul>
+<p>We should resort to forking only if the original maintainers remain unresponsive to our inquiries.
+ Currently, unresponsive means not having replied to our request within two months of repeated outreach.</p>
+
+ <h2>Project Artifact Coordinates</h2>
+
+ <p>As with transfer vs forking, artefact coordinates also need consideration. There are limitations to
+ how Clojars works, which makes it hard for a Clojars group to change ownership of a single artefact
+ within a group. This means that for certain organizations/authors, it is impossible to let CLJ Commons
+ continue artefact publication under their original group. Even so, we prefer to keep the artefact coordinates the same
+ because this will let tools like <a href="https://github.com/xsc/lein-ancient">lein-ancient</a> and <a href="https://github.com/liquidz/antq">antq</a> continue to work
+ with projects whose source is moved to the <code>clj-commons</code> organization on GitHub.
+</p>
+
+<h2>Project Maintenance</h2>
+
+<p>Once a project has been transferred to CLJ Commons, it will be maintained according to our <a href="https://clj-commons.org/maintaining-projects.html">project maintenance guidelines</a>.</p>
+
+</body>

--- a/index.html
+++ b/index.html
@@ -30,33 +30,33 @@
             Adopt important Clojure libraries when the original maintainers no longer have the time or interest to keep them updated.
         </li>
     </ul>
-    
-    
-    
-    <h2>Long Term Goals</h2>
-    <ul>
-        <li>
-            Improve the experience for beginning Clojure users by providing a clear, coherent, path towards adopting
-            Clojure
-        </li>
-        <li>Improve the experience of using Clojure for existing users by shaving off its rough edges (error messages,
-            stack traces, cryptic docstrings) and providing a unified documentation repository.
-        </li>
-        <li>Provide a common set of tools and solutions for Clojure users to adopt to reduce duplication of work.
-            “Lifting the Lisp curse”
-        </li>
-    </ul>
-    
+
+
     <h2>Contributing</h2>
-    <p>We have set up a <a href = "http://github.com/clj-commons/meta">meta-repository</a> where you can file issues for projects you want CLJ commons to adopt, or if you're interested in joining as a maintainer for a project that is dear to your heart.</p>
-    <p>Our meta-repository <a href="https://github.com/clj-commons/meta/blob/master/README.md">README</a> discusses project entry and maintenance criteria,
-        and the repo also contains our general principles of <a href="https://github.com/clj-commons/meta/blob/master/PROJECT_GOVERNANCE.md">project governance</a>.</p>
-    
+    <p>We have set up a <a href = "http://github.com/clj-commons/meta">meta-repository</a> where you can file issues for projects you want CLJ Commons to adopt, or if you're interested in joining as a maintainer for a project that is dear to your heart.</p>
+    <p>You can read more about our <a href="https://clj-commons.org/accepting-projects.html">process for accepting projects</a> and <a href="https://clj-commons.org/maintaining-projects.html">how we expect projects to be maintained</a>.</p>
+
     <h2>Projects</h2>
-    <p>You'll find a list of projects we maintain (and their current maintainers) over <a href="https://clj-commons.org/projects.html">here</a></p>
+    <p>You can see an <a href="https://clj-commons.org/projects.html">auto-generated list of projects we maintain</a> with their current maintainers.</p>
     <h2>Who's Involved?</h2>
-    <p>The CLJ Commons leadership team is made up of <a href="https://github.com/slipset">Erik Assum</a>, <a href="https://github.com/seancorfield">Sean Corfield</a>, and <a href="https://github.com/danielcompton">Daniel Compton</a>. Adopted projects are maintained by many members of the Clojure community, and you could be one of them!</p>
+    <p>The CLJ Commons leadership team is made up of <a href="https://github.com/slipset">Erik Assum</a>, <a href="https://github.com/danielcompton">Daniel Compton</a>, and <a href="https://github.com/seancorfield">Sean Corfield</a>. Adopted projects are maintained by many members of the Clojure community, and you could be one of them!</p>
 
     <h2>Contact</h2>
     <p>Please don't hesitate to contact us on the #clj-commons channel on the <a href = "http://clojurians.net">Clojurians</a> slack.</p>
+
+
+    <h2>Long Term Goals</h2>
+    <p>In addition to the current goals of maintaining projects, we would also like to be able to contribute in the following ways:</p>
+    <ul>
+        <li>
+            Improve the experience for beginning Clojure users by providing a clear, coherent, path towards adopting
+            Clojure,
+        </li>
+        <li>Improve the experience of using Clojure for existing users by shaving off its rough edges (error messages,
+            stack traces, cryptic docstrings) and providing a unified documentation repository,
+        </li>
+        <li>Provide a common set of tools and solutions for Clojure users to adopt to reduce duplication of work:
+            "Lifting the Lisp curse".
+        </li>
+    </ul>
 </body>

--- a/maintaining-projects.html
+++ b/maintaining-projects.html
@@ -1,0 +1,62 @@
+<head>
+    <style type="text/css">
+        body {
+            margin: 40px auto;
+            max-width: 650px;
+            line-height: 1.6;
+            font-size: 18px;
+            color: #444;
+            padding: 0 10px
+        }
+
+        h1,
+        h2,
+        h3 {
+            line-height: 1.2
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Maintaining Projects</h1>
+
+<p>Once a project has been accepted into CLJ Commons, there is an expectation that the project will be well-maintained, and will be kept up to date with the latest versions of Clojure and other dependencies.</p>
+
+<h2>Being a Maintainer</h2>
+
+<p>Each project under the <code>clj-commons</code> organization needs to have at least one maintainer, and the GitHub usernames of those maintainers should be listed
+ in the <code>.github/CODEOWNERS</code> file.
+ In addition, there should be a <code>ORIGINATOR</code> file added to the project root that contains the GitHub username of the person who originally created the project.</p>
+
+ <p>These files are used to automatically generate and publish the <a href="https://clj-commons.org/projects.html">list of projects</a> on the CLJ Commons website. In addition, the <code>CODEOWNERS</code> is used by GitHub to identify who should be invited to review Pull Requests for various parts of the project.</p>
+
+<p>CLJ Commons believes that the following should be considered the minimum requirements for a 'well-maintained' project:</p>
+<ul>
+<li>Passing continuous integration (see below)</li>
+<li>Responsive to issues and pull requests</li>
+<li>Documentation (<a href="https://cljdoc.org">cljdoc.org</a> makes this very easy)
+<li>Regularly creating releases</li>
+<li>Staying up to date with new Clojure and JVM releases</li>
+</ul>
+
+ <p>CLJ Commons does not impose any additional
+ restrictions on how the individual projects are run, other than what is stated in this page.</p>
+
+<p>This means that Pull Request review protocol, release cycles, and post-release announcements are up to the
+ maintainer of the project, even though we encourage announcing new releases to the <a href="https://groups.google.com/group/clojure">official Clojure Google Group</a>
+ and/or the <code>#announcements</code> / <code>#releases</code> channels in the <a href="http://clojurians.net">Clojurians Slack</a>. In addition, coding style is up to the maintainers of
+ the project, but clj-commons recommends following <a href="https://guide.clojure.style/">The Clojure Style Guide</a>.</p>
+
+<h2>Continuous Integration</h2>
+
+<p>We strongly encourage maintainers to setup and depend on Continuous Integration for all CLJ Commons projects. The founders of the project were most familiar with <a href="https://circleci.com">CircleCI</a>, so that is what most of our projects currently use -- and you'll find it easy to get help from other CLJ Commons maintainers if you have questions about CircleCI.</p>
+
+<p>The CircleCI GitHub application is already configured at the organization level. Simply adding a valid configuration (<a href="https://circleci.com/docs/2.0/language-clojure/">check the official documentation</a>) is enough to enable Continuous Integration (of branches and pull requests).</p>
+
+<p>You can also use GitHub Actions if you are more comfortable with that.</p>
+
+<h2>Project Acceptance</h2>
+
+<p>How projects get accepted by CLJ Commons is discussed in our <a href="https://clj-commons.org/accepting-projects.html">project acceptance guidelines</a>.</p>
+
+</body>


### PR DESCRIPTION
The goal here is to bring information about how we adopt and maintain projects onto the main website instead of being split between the website and various markdown pages in the Meta repo.

I've gathered up both material from the Meta README and the project governance file, and organized it cleanly into acceptance and maintenance.

If we merge and publish this, I plan to edit the Meta README to link to these new pages and remove content that is duplicated there. I'll also remove the project governance markdown file (since it is completely subsumed into these changes).

I think we should also turn off the Wiki in the Meta repo.